### PR TITLE
Allowing multiple /24 address ranges to be used for one VNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,15 @@ module "spokesetup" {
   resource_group          = azurerm_resource_group.rg
   prefix                  = local.ProjectIdentity
   address                 = local.MAIN_ADDRESS
+  address2                = local.MAIN_ADDRESS_2
   dns_servers             = local.DNS_SERVERS
   subnets                 = local.SUBNETS
   newbits                 = local.NEWBITS
   service_endpoints       = local.MAIN_ENDPOINTS
 }  
 ```
+
+Note: address2 is an optional variable to be used if the address range of the VNet needs to be extended beyond 256 addresses
 
 if you arent woried about the version you use, latest can be retrieved by removing `?ref=x.y.z` from source path
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  base_cidr_block = var.address
+  base_cidr_block = var.address2 != null ? var.address2 : [var.address, var.address2]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  base_cidr_block = var.address2 != null ? var.address2 : [var.address, var.address2]
+  base_cidr_block = var.address2 != null ? [var.address2] : [var.address, var.address2]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,10 +14,15 @@ variable "address" {
   description = "base address for subnets to be added"
 }
 
+variable "address2" {
+  description = "extension address for subnets to be added"
+  type    = string
+  default = null
+}
+
 variable "dns_servers" {
   description = "ips for dns server"
 }
-
 
 variable "subnets" {
   description = "Array of subnets. Each subnet can optionally have delegation."


### PR DESCRIPTION
Allows for an extra variable (address2) to be passed optionally to this module which extends the address space of the VNet that is created